### PR TITLE
v0.2.1: Update Terraform Plan and Apply jobs

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -45,14 +45,14 @@ jobs:
               id: plan
               run: |
                 set +e
-                output=$(terraform plan -var-file ${{ vars.TERRAFORM_TFVARS_FILE }} -no-color -out=tfplan)
+                output=$(terraform plan -var-file ${{ vars.TERRAFORM_TFVARS_FILE }} -no-color)
                 echo "$output"
                 echo "::set-output name=has_changes::$(echo "$output" | grep -qE "\+ create|~ update in-place" && echo "true" || echo "false")"
               working-directory: terraform
       
             - name: Terraform Apply
               if: steps.plan.outputs.has_changes == 'true'
-              run: terraform apply -var-file ${{ vars.TERRAFORM_TFVARS_FILE }} -auto-approve tfplan
+              run: terraform apply -var-file ${{ vars.TERRAFORM_TFVARS_FILE }} -auto-approve
               working-directory: terraform
     
     deploy-api:


### PR DESCRIPTION
The Terraform Plan job has been updated to remove the -out=tfplan option, meaning the plan will no longer be saved to a file named tfplan. Similarly, the Terraform Apply job has been modified to remove the tfplan argument, so it will no longer use a saved plan from a file named tfplan. Instead, it will directly apply the changes based on the current state and configuration.