### PR TITLE
Deploy Action: Fix Push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,12 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "::set-output name=environment::${{ github.event.inputs.environment }}"
-          elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
-            echo "::set-output name=environment::Development"
-          else
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "::set-output name=environment::Production"
+          elif [[ "${{ github.ref }}" == refs/heads/release/* ]] || [[ "${{ github.ref }}" == refs/heads/hotfix/* ]]; then
+            echo "::set-output name=environment::Staging"
+          else
+            echo "::set-output name=environment::Development"
           fi
 
   terraform-apply:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ on:
             options:
                 - 'Development'
                 #- 'Staging'
+                #- 'Production'
         
 
 env:
@@ -25,11 +26,29 @@ env:
   ARM_TENANT_ID: ${{ vars.AZURE_TERRAFORM_APP_TENANT_ID }}
 
 jobs:
+  set-env:
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.set-env.outputs.environment }}
+
+    steps:
+      - name: Set environment
+        id: set-env
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "::set-output name=environment::${{ github.event.inputs.environment }}"
+          elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            echo "::set-output name=environment::Development"
+          else
+            echo "::set-output name=environment::Production"
+          fi
+
   terraform-apply:
+    needs: set-env
     name: 'Deploy Infrastructure'
     runs-on: ubuntu-latest
     environment:
-        name: ${{ github.event.inputs.environment }}
+      name: ${{ needs.set-env.outputs.environment }}
     env:
       TF_VAR_system_admin_email: ${{ vars.SYSTEM_ADMIN_EMAIL }}
       TF_VAR_manager_email: ${{ vars.MANAGER_EMAIL }}
@@ -38,84 +57,40 @@ jobs:
       TF_VAR_nebamgmt_mssql_admin_password: ${{ secrets.SQL_SERVER_ADMIN_PASSWORD }}
         
     steps:
-        - name: Checkout
-          uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-        - name: Setup Terraform
-          uses: hashicorp/setup-terraform@v3
-        
-        - name: Terraform Init
-          run: terraform init -backend-config="resource_group_name=${{ vars.AZURE_INFRASTRUCTURE_RESOURCE_GROUP_NAME }}" -backend-config="storage_account_name=${{ vars.AZURE_INFRASTRUCTURE_STORAGE_ACCOUNT_NAME }}" -backend-config="container_name=${{ vars.AZURE_TERRAFORM_STORAGE_CONTAINER_NAME }}" -backend-config="key=${{ vars.TERRAFORM_STATE_FILE_NAME }}"
-          working-directory: terraform
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+      
+      - name: Terraform Init
+        run: terraform init -backend-config="resource_group_name=${{ vars.AZURE_INFRASTRUCTURE_RESOURCE_GROUP_NAME }}" -backend-config="storage_account_name=${{ vars.AZURE_INFRASTRUCTURE_STORAGE_ACCOUNT_NAME }}" -backend-config="container_name=${{ vars.AZURE_TERRAFORM_STORAGE_CONTAINER_NAME }}" -backend-config="key=${{ vars.TERRAFORM_STATE_FILE_NAME }}"
+        working-directory: terraform
 
-        - name: Terraform Validate
-          run: terraform validate
-          working-directory: terraform
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: terraform
 
-        - name: Terraform Plan
-          run: terraform plan -var-file ${{ vars.TERRAFORM_TFVARS_FILE }} -out terraplan
-          working-directory: terraform
+      - name: Terraform Plan
+        run: terraform plan -var-file ${{ vars.TERRAFORM_TFVARS_FILE }} -out terraplan
+        working-directory: terraform
 
-        - name: Terraform Apply
-          run: terraform apply terraplan -auto-approve
-          working-directory: terraform
+      - name: Terraform Apply
+        run: terraform apply terraplan -auto-approve
+        working-directory: terraform
 
   api:
       name: 'Deploy API'
       runs-on: ubuntu-latest
-      needs: terraform-apply
+      needs: [set-env, terraform-apply]
       env:
-          CONFIGURATION: Release
-          DOTNET_CORE_VERSION: 8.0.x
-          WORKING_DIRECTORY: src/Neba.Api
-      environment:
-        name: ${{ github.event.inputs.environment }}
-      
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v4
-
-          - name: Setup .NET
-            uses: actions/setup-dotnet@v4
-            with:
-                dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
-
-          - name: Login to Azure
-            uses: azure/login@v2
-            with:
-              creds: '{"clientId":"${{ vars.AZURE_TERRAFORM_APP_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_TERRAFORM_APP_CLIENT_SECRET }}","subscriptionId":"${{ vars.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ vars.AZURE_TERRAFORM_APP_TENANT_ID }}"}'
-        
-          - name: Restore
-            run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
-          
-          - name: Build
-            run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
-
-          - name: Publish
-            run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --output ./publishApi
-
-          - name: Archive Published Files
-            run: |
-              cd publishApi
-              zip -r ../publishApi.zip *
-
-          - name: Deploy API
-            run: |
-              az configure --defaults group=${{ vars.AZURE_RESOURCE_GROUP_NAME }} web=${{ vars.AZURE_API_SERVICE_NAME }}
-              az webapp deployment source config-zip --src ./publishApi.zip --name ${{ vars.AZURE_API_SERVICE_NAME }} --resource-group ${{ vars.AZURE_RESOURCE_GROUP_NAME }}
-
-  ui:
-    name: 'Deploy UI'
-    runs-on: ubuntu-latest
-    needs: terraform-apply
-    env:
         CONFIGURATION: Release
         DOTNET_CORE_VERSION: 8.0.x
-        WORKING_DIRECTORY: src/Neba.UI
-    environment:
-      name: ${{ github.event.inputs.environment }}
-    
-    steps:
+        WORKING_DIRECTORY: src/Neba.Api
+      environment:
+        name: ${{ needs.set-env.outputs.environment }}
+      
+      steps:
         - name: Checkout
           uses: actions/checkout@v4
 
@@ -136,14 +111,58 @@ jobs:
           run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
 
         - name: Publish
-          run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --output ./publishUI
+          run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --output ./publishApi
 
         - name: Archive Published Files
           run: |
-            cd publishUI
-            zip -r ../publishUI.zip *
-        
-        - name: Deploy UI
+            cd publishApi
+            zip -r ../publishApi.zip *
+
+        - name: Deploy API
           run: |
-            az configure --defaults group=${{ vars.AZURE_RESOURCE_GROUP_NAME }} web=${{ vars.AZURE_UI_SERVICE_NAME }}
-            az webapp deployment source config-zip --src ./publishUI.zip --name ${{ vars.AZURE_UI_SERVICE_NAME }} --resource-group ${{ vars.AZURE_RESOURCE_GROUP_NAME }}
+            az configure --defaults group=${{ vars.AZURE_RESOURCE_GROUP_NAME }} web=${{ vars.AZURE_API_SERVICE_NAME }}
+            az webapp deployment source config-zip --src ./publishApi.zip --name ${{ vars.AZURE_API_SERVICE_NAME }} --resource-group ${{ vars.AZURE_RESOURCE_GROUP_NAME }}
+
+  ui:
+    name: 'Deploy UI'
+    runs-on: ubuntu-latest
+    needs: [set-env, terraform-apply]
+    env:
+        CONFIGURATION: Release
+        DOTNET_CORE_VERSION: 8.0.x
+        WORKING_DIRECTORY: src/Neba.UI
+    environment:
+      name: ${{ needs.set-env.outputs.environment }}
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+            dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          creds: '{"clientId":"${{ vars.AZURE_TERRAFORM_APP_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_TERRAFORM_APP_CLIENT_SECRET }}","subscriptionId":"${{ vars.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ vars.AZURE_TERRAFORM_APP_TENANT_ID }}"}'
+    
+      - name: Restore
+        run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
+      
+      - name: Build
+        run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
+
+      - name: Publish
+        run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --output ./publishUI
+
+      - name: Archive Published Files
+        run: |
+          cd publishUI
+          zip -r ../publishUI.zip *
+      
+      - name: Deploy UI
+        run: |
+          az configure --defaults group=${{ vars.AZURE_RESOURCE_GROUP_NAME }} web=${{ vars.AZURE_UI_SERVICE_NAME }}
+          az webapp deployment source config-zip --src ./publishUI.zip --name ${{ vars.AZURE_UI_SERVICE_NAME }} --resource-group ${{ vars.AZURE_RESOURCE_GROUP_NAME }}


### PR DESCRIPTION
# Pull Request Description

This pull request introduces several changes to our CI/CD pipeline, primarily focusing on the environment setup and job dependencies. The changes are aimed at improving the efficiency and clarity of our pipeline.

## Changes Made

1. **Environment Choice Options:** The 'Staging' and 'Production' options have been commented out. This is a temporary measure to prevent accidental deployments to these environments.

2. **New Job 'set-env':** A new job 'set-env' has been added. This job sets the environment based on the GitHub event name or the GitHub ref. This change allows us to dynamically set the environment, making our pipeline more flexible.

3. **Job Dependencies:** The 'terraform-apply', 'api', and 'ui' jobs now depend on the 'set-env' job. This ensures that the environment is set before these jobs run. The 'api' and 'ui' jobs also depend on the 'terraform-apply' job, ensuring that the infrastructure is set up before the application is deployed.

4. **Changes to 'api' Job:** The 'Publish' step in the 'api' job now outputs to './publishApi' instead of './publishUI'. The 'Archive Published Files' step now archives the files in 'publishApi' directory instead of 'publishUI' directory. The 'Deploy API' step now deploys the API using the files in 'publishApi.zip' instead of 'publishUI.zip'. These changes ensure that the 'api' job is self-contained and does not interfere with the 'ui' job.

5. **Changes to 'ui' Job:** The 'ui' job has been reintroduced. The 'Publish' step outputs to './publishUI'. The 'Archive Published Files' step archives the files in 'publishUI' directory. The 'Deploy UI' step deploys the UI using the files in 'publishUI.zip'. This ensures that the 'ui' job is self-contained and does not interfere with the 'api' job.

## Significant Design Decisions

The decision to make the 'terraform-apply', 'api', and 'ui' jobs dependent on the 'set-env' job is significant. This design decision ensures that the environment is set before any other jobs run, improving the reliability of our pipeline. The changes to the 'api' and 'ui' jobs ensure that these jobs are self-contained, improving the clarity and maintainability of our pipeline.
