### PR TITLE
Update SonarCloud workflow to install DotNet Coverage tool

### DIFF
--- a/.github/workflows/step-sonarcloud.yml
+++ b/.github/workflows/step-sonarcloud.yml
@@ -51,7 +51,6 @@ jobs:
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
 
       - name: Install DotNet Coverage
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         run: dotnet tool update -g dotnet-coverage
 
       - name: Build and analyze

--- a/.github/workflows/step-sonarcloud.yml
+++ b/.github/workflows/step-sonarcloud.yml
@@ -59,7 +59,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"bowlneba_neba-management" /o:"bowlneba" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"bowlneba_neba-management" /o:"bowlneba" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.host.url="https://sonarcloud.io"
           dotnet build
           dotnet coverage collect "dotnet test --no-build"  -f xml -o "coverage.xml"
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/step-sonarcloud.yml
+++ b/.github/workflows/step-sonarcloud.yml
@@ -50,6 +50,10 @@ jobs:
           New-Item -Path .\.sonar\scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
 
+      - name: Install DotNet Coverage
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        run: dotnet tool update -g dotnet-coverage
+
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow to install a new tool for code coverage. The most important change is the addition of a step to install `dotnet-coverage` if it is not already cached.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/step-sonarcloud.yml`](diffhunk://#diff-32f4348b589a90c1eb1bbcb13d93ba3d0711e774890bc36d1b94f1106ffcfbe5R53-R56): Added a step to install `dotnet-coverage` if it is not already cached.